### PR TITLE
Creating get_status_colored method + changing the status position in …

### DIFF
--- a/gme.py
+++ b/gme.py
@@ -80,6 +80,19 @@ def filter_same_domain(urls, base_domain):
     """Filters URLs to include only those from the same domain."""
     return [url for url in urls if base_domain in urlparse(url).netloc]
 
+
+# Function to show http status color coded
+def get_status_colored(status_code):
+    if status_code < 300:
+        return f"{Fore.GREEN}{status_code}"  # OK responses are green
+    elif status_code < 400:
+        return f"{Fore.BLUE}{status_code}"  # Redirection responses are green
+    elif status_code < 500:
+        return f"{Fore.YELLOW}{status_code}"  # Client errors are yellow
+    else:
+        return f"{Fore.RED}{status_code}"  # Server errors are red
+
+
 # Function to evaluate URLs (fetch status code and title) 
 
 def evaluate_url(url):
@@ -88,7 +101,7 @@ def evaluate_url(url):
         soup = BeautifulSoup(response.text, 'lxml')  # Use 'lxml' for parsing
         title = soup.title.string if soup.title else 'No Title'
         status_code = response.status_code
-        print(f"{Fore.CYAN}URL: {url} {Fore.GREEN}Status: {status_code} {Fore.YELLOW}Title: {title}")
+        print("[",get_status_colored(status_code),"]",f"{Fore.CYAN}URL: {url}",f"{Fore.YELLOW}Title: {title}")
         return (url, status_code, title)
     except requests.RequestException:
         print(f"{Fore.CYAN}URL: {url} {Fore.RED}Status: Failed to connect {Fore.YELLOW}Title: No Title")


### PR DESCRIPTION
Hi Yara,
This is Mohammad Almazroa :)

Well done on creating this handy tool. I've updated the code to add color-coding for the response status. Here's what I changed:

```python
# Function to show http status color coded
def get_status_colored(status_code):
    if status_code < 300:
        return f"{Fore.GREEN}{status_code}"  # OK responses are green
    elif status_code < 400:
        return f"{Fore.BLUE}{status_code}"  # Redirection responses are green
    elif status_code < 500:
        return f"{Fore.YELLOW}{status_code}"  # Client errors are yellow
    else:
        return f"{Fore.RED}{status_code}"  # Server errors are red
```

I've also adjusted the placement of the status code in the output:
![image](https://github.com/user-attachments/assets/b970bbf4-9c55-4e91-bc30-958b9b468f94)

I hope you like these changes 👍.

Good luck